### PR TITLE
Fix for non root user <Do not merge>

### DIFF
--- a/examples/kubernetes/cos-s3-csi-pvc-secret.yaml
+++ b/examples/kubernetes/cos-s3-csi-pvc-secret.yaml
@@ -24,7 +24,8 @@ data:
   # echo -n "<secret kye>" | base64
   accessKey: bXktYWNjZXNzLWtleQ==
   secretKey: bXktc2VjcmV0LWtleQ==
-stringData: 
+stringData:
+  # uid: "3000" # Provide uid to run as non root user. This must match runAsUser in SecurityContext of pod spec.
   mountOptions: |
     upload_concurrency=30
     low_level_retries=3

--- a/pkg/mounter/mounter-rclone.go
+++ b/pkg/mounter/mounter-rclone.go
@@ -188,8 +188,13 @@ func (rclone *rcloneMounter) Mount(source string, target string) error {
 		"mount",
 		bucketName,
 		target,
+		"--allow-other",
 		"--daemon",
 		"--log-file=/var/log/rclone.log",
+	}
+	for _, val := range rclone.mountOptions {
+		val = "--" + val
+		args = append(args, val)
 	}
 	return fuseMount(target, rcloneCmd, args)
 }


### PR DESCRIPTION

How mount options are passed in rclone. (Diff from s3fs)
```
/usr/bin/rclone mount ibmcos:rcloneuidtest  /tmp/rclone  --allow-other  --uid=3000 --gid=2000 --daemon 
[root@cos-s3-csi-driver-xf56w /]# ls -lh  /tmp/rclone
total 512
-rw-r--r--. 1 3000 2000 5 Apr  2 14:51 gotalife.txt
[root@cos-s3-csi-driver-xf56w /]# 

```


**rclone positive test results**
```
kubectl get secret -o yaml cos-s3-csi-pvc-rclone  | grep uid
  uid: MzAwMA==
  uid: 9d8c01c0-bd2d-4127-8057-48053be96dab
root@devVm1:~# echo "MzAwMA==" | base64 -d
3000root@devVm1:~# 
root@devVm1:~# 
root@devVm1:~# 
root@devVm1:~# kubectl get pvc
kNAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
cos-s3-csi-pvc-rclone   Bound    pvc-1ac6f27f-5460-4efc-88bd-7c9ec1ceb558   256Mi      RWO            cos-s3-csi-rclone-sc   7h32m
cos-s3-csi-pvc-s3fs     Bound    pvc-f3effaf2-a5ea-4ebe-9339-c38dff69b413   256Mi      RWO            cos-s3-csi-s3fs-sc     10h
root@devVm1:~# kubectl get pods
NAME                 READY   STATUS    RESTARTS   AGE
cos-csi-app-rclone   1/1     Running   0          7h30m
cos-csi-app-s3fs     1/1     Running   0          8h
root@devVm1:~# kubectl get pod -o yaml cos-csi-app-rclone | grep fsGroup
    fsGroup: 2000
root@devVm1:~# kubectl get pod -o yaml cos-csi-app-rclone | grep runAsUser
    runAsUser: 3000
root@devVm1:~# kubectl exec -it cos-csi-app-rclone /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
groups: cannot find name for group ID 2000
3000@cos-csi-app-rclone:/$ id
uid=3000(3000) gid=2000 groups=2000
3000@cos-csi-app-rclone:/$ ls -lh /data
total 512
-rw-r--r--. 1 3000 2000 8 Apr  2 16:24 gotalife.txt
3000@cos-csi-app-rclone:/$ echo "check" > /data/new.txt
3000@cos-csi-app-rclone:/$ ls -lh /data
total 1.0K
-rw-r--r--. 1 3000 2000 8 Apr  2 16:24 gotalife.txt
-rw-r--r--. 1 3000 2000 6 Apr  2 23:52 new.txt
3000@cos-csi-app-rclone:/$ 
3000@cos-csi-app-rclone:/$ 
3000@cos-csi-app-rclone:/$ exit
exit
root@devVm1:~# 

```
**rclone positive test results**

```
root@devVm1:~/workspace/src/github.com/IBM/ibm-object-csi-driver# kubectl exec -it cos-csi-app-rclone /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
root@cos-csi-app-rclone:/# id
uid=0(root) gid=0(root) groups=0(root)
root@cos-csi-app-rclone:/# ls -lh /data
total 1.0K
-rw-r--r--. 1 3000 root 8 Apr  2 16:24 gotalife.txt
-rw-r--r--. 1 3000 root 6 Apr  2 23:52 new.txt
root@cos-csi-app-rclone:/# cat /data/gotalife.txt 
gwgwgwg
root@cos-csi-app-rclone:/# cat /data/new.txt 
check
root@cos-csi-app-rclone:/# echo "test" > temp.txt
root@cos-csi-app-rclone:/# cp temp.txt /data/gotalife.txt 
root@cos-csi-app-rclone:/# cp temp.txt /data/new.txt 
root@cos-csi-app-rclone:/# mv temp.txt  /data/gotalife.txt 
root@cos-csi-app-rclone:/# ls -lh /data
total 1.0K
-rw-r--r--. 1 3000 root 5 Apr  2 23:55 gotalife.txt
-rw-r--r--. 1 3000 root 5 Apr  2 23:55 new.txt
root@cos-csi-app-rclone:/# 
```

**s3fs test results**

```
kubectl create -f cos-csi-app-s3fs.yaml
pod/cos-csi-app-s3fs created
root@devVm1:~/workspace/src/github.com/IBM/ibm-object-csi-driver# kubectl get pods
NAME               READY   STATUS    RESTARTS   AGE
cos-csi-app-s3fs   1/1     Running   0          3s
root@devVm1:~/workspace/src/github.com/IBM/ibm-object-csi-driver# kubectl exec -it cos-csi-app-s3fs /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
groups: cannot find name for group ID 2000
groups: cannot find name for group ID 1000
3000@cos-csi-app-s3fs:/$ id
uid=3000(3000) gid=2000 groups=2000,1000
3000@cos-csi-app-s3fs:/$ ls -lh /data
total 1.0K
-rw-r--r--. 1 3000 1000 8 Apr  2 13:43 test.txt
-rw-r--r--. 1 3000 1000 3 Apr  2 13:43 test2.txt
3000@cos-csi-app-s3fs:/$ cat /data/test.txt 
test
hi
3000@cos-csi-app-s3fs:/$ echo "chek" >> /data/test.txt 
3000@cos-csi-app-s3fs:/$ cat /data/test.txt 
test
hi
chek
3000@cos-csi-app-s3fs:/$ exit
exit
root@devVm1:~/workspace/src/github.com/IBM/ibm-object-csi-driver# kubectl get pods
NAME               READY   STATUS    RESTARTS   AGE
cos-csi-app-s3fs   1/1     Running   0          60s
root@devVm1:~/workspace/src/github.com/IBM/ibm-object-csi-driver# kubectl delete pod cos-csi-app-s3fs 
pod "cos-csi-app-s3fs" deleted
root@devVm1:~/workspace/src/github.com/IBM/ibm-object-csi-driver# kubectl create -f cos-csi-app-s3fs-root.yaml
pod/cos-csi-app-s3fs created
root@devVm1:~/workspace/src/github.com/IBM/ibm-object-csi-driver# kubectl exec -it cos-csi-app-s3fs /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
root@cos-csi-app-s3fs:/# id
uid=0(root) gid=0(root) groups=0(root)
root@cos-csi-app-s3fs:/# ls -lh /data
total 1.0K
-rw-r--r--. 1 3000 root 13 Apr  2 14:10 test.txt
-rw-r--r--. 1 3000 2000  3 Apr  2 13:43 test2.txt
root@cos-csi-app-s3fs:/# cat /data/test.txt 
test
hi
chek
root@cos-csi-app-s3fs:/# cat /data/test2.txt 
hi
root@cos-csi-app-s3fs:/# echo "new" > /data/test2.txt 
root@cos-csi-app-s3fs:/# cat /data/test2.txt 
new
root@cos-csi-app-s3fs:/# cat /data/test.txt 
test
hi
chek
root@cos-csi-app-s3fs:/# echo "new" > /data/test.txt 
root@cos-csi-app-s3fs:/# cat /data/test.txt 
new
root@cos-csi-app-s3fs:/# exit
exit
root@devVm1:~/workspace/src/github.com/IBM/ibm-object-csi-driver# 
```