### PR TITLE
Enhancement for non root user 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Provide proper values for parameters in secret under examples/cos-s3-csi-pvc-sec
             low_level_retries=3
     ```
 
+    For non-root user support, in the Secret  user can add `uid` which must match `RunAsUser` in Pod spec.
+    
+    ```
+    stringData:
+      uid: "3000" # Provide uid to run as non root user. This must match runAsUser in SecurityContext of pod spec.
+    ```
+    User can skip changes in Secret and directly use Pod Spec to enforce non root volume mount by providing `RunAsUser` value same as `FsGroup`.
+
 2. Verify PVC is in `Bound` state
 
 3. Check for successful mount

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -155,16 +155,9 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		}
 		secretMapCopy[k] = v
 	}
-	secretUid := secretMap["uid"]
 	klog.V(2).Infof("-NodePublishVolume-: secretMap: %v", secretMapCopy)
 	if volumeMountGroup != "" {
-		mountFlags = append(mountFlags, fmt.Sprintf("gid=%s", volumeMountGroup))
-	}
-
-	if volumeMountGroup != ""  && secretUid == "" {
-		mountFlags = append(mountFlags, fmt.Sprintf("uid=%s", volumeMountGroup))
-	} else if secretUid !="" {
-		mountFlags = append(mountFlags, fmt.Sprintf("uid=%s", secretUid))
+		secretMap["gid"] = volumeMountGroup
 	}
 
 	// If bucket name wasn't provided by user, we use temp bucket created for volume.

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -155,12 +155,15 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		}
 		secretMapCopy[k] = v
 	}
+	secretUid := secretMap["uid"]
 	klog.V(2).Infof("-NodePublishVolume-: secretMap: %v", secretMapCopy)
 	if volumeMountGroup != "" {
 		mountFlags = append(mountFlags, fmt.Sprintf("gid=%s", volumeMountGroup))
 	}
-	secretUid := secretMap["uid"]
-	if secretUid != "" {
+
+	if volumeMountGroup != ""  && secretUid == "" {
+		mountFlags = append(mountFlags, fmt.Sprintf("uid=%s", volumeMountGroup))
+	} else if secretUid !="" {
 		mountFlags = append(mountFlags, fmt.Sprintf("uid=%s", secretUid))
 	}
 

--- a/pkg/mounter/mounter-rclone.go
+++ b/pkg/mounter/mounter-rclone.go
@@ -30,6 +30,8 @@ type rcloneMounter struct {
 	locConstraint string //From Secret in SC
 	authType      string
 	accessKeys    string
+	uid           string
+	gid           string
 	mountOptions  []string
 }
 
@@ -122,6 +124,15 @@ func newRcloneMounter(secretMap map[string]string, mountOptions []string) (Mount
 		mounter.authType = "hmac"
 	}
 
+	if val, check = secretMap["gid"]; check {
+		mounter.gid = val
+	}
+	if secretMap["gid"] != "" && secretMap["uid"] == "" {
+		mounter.uid = secretMap["gid"]
+	} else if secretMap["uid"] != "" {
+		mounter.uid = secretMap["uid"]
+	}
+
 	klog.Infof("newRcloneMounter args:\n\tbucketName: [%s]\n\tobjPath: [%s]\n\tendPoint: [%s]\n\tlocationConstraint: [%s]\n\tauthType: [%s]",
 		mounter.bucketName, mounter.objPath, mounter.endPoint, mounter.locConstraint, mounter.authType)
 
@@ -192,9 +203,13 @@ func (rclone *rcloneMounter) Mount(source string, target string) error {
 		"--daemon",
 		"--log-file=/var/log/rclone.log",
 	}
-	for _, val := range rclone.mountOptions {
-		val = "--" + val
-		args = append(args, val)
+	if rclone.gid != "" {
+		gidOpt := "--gid=" + rclone.gid
+		args = append(args, gidOpt)
+	}
+	if rclone.uid != "" {
+		uidOpt := "--uid=" + rclone.uid
+		args = append(args, uidOpt)
 	}
 	return fuseMount(target, rcloneCmd, args)
 }

--- a/pkg/mounter/mounter-s3fs.go
+++ b/pkg/mounter/mounter-s3fs.go
@@ -78,6 +78,7 @@ func newS3fsMounter(secretMap map[string]string, mountOptions []string) (Mounter
 	if val, check = secretMap["apiKey"]; check {
 		apiKey = val
 	}
+
 	if apiKey != "" {
 		mounter.accessKeys = fmt.Sprintf(":%s", apiKey)
 		mounter.authType = "iam"
@@ -116,6 +117,17 @@ func newS3fsMounter(secretMap map[string]string, mountOptions []string) (Mounter
 	}
 	if val, check = secretMap["use_cache"]; check {
 		option = fmt.Sprintf("use_cache=%s", val)
+		options = append(options, option)
+	}
+	if val, check = secretMap["gid"]; check {
+		option = fmt.Sprintf("gid=%s", val)
+		options = append(options, option)
+	}
+	if secretMap["gid"] != "" && secretMap["uid"] == "" {
+		option = fmt.Sprintf("uid=%s", secretMap["gid"])
+		options = append(options, option)
+	} else if secretMap["uid"] != "" {
+		option = fmt.Sprintf("uid=%s", secretMap["uid"])
 		options = append(options, option)
 	}
 


### PR DESCRIPTION
If uid `uid` is  not provided in secret but fsGroup is mentioned in Pod spec make uid = gid and pass in mount options


Test results - https://github.ibm.com/alchemy-containers/armada-storage/issues/5783