### PR TITLE
Log fuse mount error

### DIFF
--- a/pkg/mounter/mounter.go
+++ b/pkg/mounter/mounter.go
@@ -3,14 +3,13 @@ package mounter
 import (
 	"errors"
 	"fmt"
+	"github.com/IBM/ibm-object-csi-driver/pkg/constants"
+	"k8s.io/klog/v2"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
 	"time"
-
-	"github.com/IBM/ibm-object-csi-driver/pkg/constants"
-	"k8s.io/klog/v2"
 )
 
 type Mounter interface {
@@ -61,17 +60,11 @@ func fuseMount(path string, comm string, args []string) error {
 	klog.Info("-fuseMount-")
 	klog.Infof("fuseMount args:\n\tpath: <%s>\n\tcommand: <%s>\n\targs: <%s>", path, comm, args)
 	cmd := command(comm, args...)
-	err := cmd.Start()
-
+	// Execute the command and capture its combined output
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Errorf("fuseMount: cmd start failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, err)
-		return fmt.Errorf("fuseMount: cmd start failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, err)
-	}
-	err = cmd.Wait()
-	if err != nil {
-		// Handle error
-		klog.Errorf("fuseMount: cmd wait failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, err)
-		return fmt.Errorf("fuseMount: cmd wait failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, err)
+		klog.Errorf("fuseMount: cmd start failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, string(output))
+		return fmt.Errorf("fuseMount: cmd start failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, string(output))
 	}
 
 	return waitForMount(path, 10*time.Second)

--- a/pkg/mounter/mounter.go
+++ b/pkg/mounter/mounter.go
@@ -63,8 +63,8 @@ func fuseMount(path string, comm string, args []string) error {
 	// Execute the command and capture its combined output
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Errorf("fuseMount: cmd start failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, string(output))
-		return fmt.Errorf("fuseMount: cmd start failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, string(output))
+		klog.Errorf("fuseMount: cmd failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, string(output))
+		return fmt.Errorf("fuseMount: cmd failed: <%s>\nargs: <%s>\nerror: <%v>", comm, args, string(output))
 	}
 
 	return waitForMount(path, 10*time.Second)


### PR DESCRIPTION
## Describe your changes

When there is any error while mounting bucket, logs shows only exit status. Reason for failure is not printed which makes it difficult to debug.  

```
E0509 06:43:14.320134       1 server.go:158] GRPC error: fuseMount: cmd wait failed: <s3fs>
args: <[bha-test-m9 /var/data/kubelet/pods/3a8b6b40-df9f-487b-bd52-d43706bb2e12/volumes/kubernetes.io~csi/pvc-fd591a44-ec22-402b-9333-e0bba0b911c0/mount -o sigv2 -o use_path_request_style -o passwd_file=/var/lib/ibmc-s3fs/6ef3bbf5abef020239f77de54d8bf5f20d64d50daebfd14a64486d3da96570ff/.passwd-s3fs -o url=https://s3.direct.jp-osa.cloud-object-storage.appdomain.cloud/ -o endpoint=jp-osa-standard -o allow_other -o mp_umask=002 -o retries=5 -o kernel_cache -o upload_concurrency=30 -o low_level_retries=3 -o multipart_size=62 -o max_dirty_data=51200 -o parallel_count=8 -o max_stat_cache_size=100000 -o default_acl=private]>
error: <exit status 1>
```
After code change

```
  Warning  FailedMount  6s  kubelet  MountVolume.SetUp failed for volume "pvc-cb507f72-f113-4679-85d4-81e8cc295918" : rpc error: code = Unknown desc = fuseMount: cmd start failed: <s3fs>
args: <[bha-test-m9 /var/data/kubelet/pods/0c4c4327-ef5f-4bc8-8d8e-09bb9ef9afc6/volumes/kubernetes.io~csi/pvc-cb507f72-f113-4679-85d4-81e8cc295918/mount -o sigv2 -o use_path_request_style -o passwd_file=/var/lib/ibmc-s3fs/bf3deb8f76edabc08fd488387ba0fe24edb09ef1498deede6f3a6ae85454db27/.passwd-s3fs -o url=https://s3.direct.jp-osa.cloud-object-storage.appdomain.cloud -o endpoint=jp-osa-standard -o allow_other -o mp_umask=002 -o upload_concurrency=30 -o low_level_retries=3 -o multipart_size=62 -o max_dirty_data=51200 -o parallel_count=8 -o max_stat_cache_size=100000 -o retries=5 -o kernel_cache -o default_acl=private]>
error: <fuse: unknown option `upload_concurrency=30'
>
```

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have made sure existing UTs are not impacted
- [ ] I have executed all necessary linter and made sure internal pipeline/travis is not broken

